### PR TITLE
Add type annotations

### DIFF
--- a/emrichen/__init__.py
+++ b/emrichen/__init__.py
@@ -1,6 +1,8 @@
+from typing import TextIO, Union
+
 from .context import Context
-from .template import Template
 from .tags import Var
+from .template import Template
 
 __version__ = '0.2.3'
 
@@ -8,7 +10,7 @@ __version__ = '0.2.3'
 __all__ = ['Context', 'Template', 'Var', 'emrichen']
 
 
-def emrichen(template, *variable_sources, **override_variables):
+def emrichen(template: Union[str, TextIO], *variable_sources, **override_variables) -> str:
     """
     Renders the template using the given variable sources and variable overrides.
 

--- a/emrichen/__main__.py
+++ b/emrichen/__main__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import List, Optional
 
 from .cli import get_parser
 from .context import Context
@@ -7,7 +8,7 @@ from .output import RENDERERS
 from .template import Template, determine_format
 
 
-def main(args=None):
+def main(args: Optional[List[str]] = None) -> None:
     if args is None:
         args = sys.argv[1:]
     parser = get_parser()

--- a/emrichen/cli.py
+++ b/emrichen/cli.py
@@ -5,7 +5,7 @@ from .input import PARSERS
 from .output import RENDERERS
 
 
-def get_parser(with_pargs=True):
+def get_parser(with_pargs=True) -> argparse.ArgumentParser:
     """
     Returns the Emrichen command line parser.
 

--- a/emrichen/context.py
+++ b/emrichen/context.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
-from typing import Any
 
 from .void import Void
 
@@ -15,7 +14,7 @@ class Context(dict):
         super().__init__()
         self.add_variables(*variable_sources, **override_variables)
 
-    def enrich(self, value: Any) -> Any:
+    def enrich(self, value):
         """
         Given a YAML value, performs our registered transformations on it.
         """

--- a/emrichen/context.py
+++ b/emrichen/context.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
+from typing import Any
 
-from .input import parse
 from .void import Void
 
 
@@ -11,10 +11,11 @@ class Context(dict):
     YAML values using them.
     """
 
-    def __init__(self, *variable_sources, **override_variables):
+    def __init__(self, *variable_sources, **override_variables) -> None:
+        super().__init__()
         self.add_variables(*variable_sources, **override_variables)
 
-    def enrich(self, value):
+    def enrich(self, value: Any) -> Any:
         """
         Given a YAML value, performs our registered transformations on it.
         """
@@ -42,7 +43,7 @@ class Context(dict):
         else:
             return value
 
-    def add_variables(self, *variable_sources, **override_variables):
+    def add_variables(self, *variable_sources, **override_variables) -> None:
         """
         Adds one or more sources of variables into this Context. If the same variable is defined
         by multiple sources, the last one takes precedence.
@@ -51,6 +52,7 @@ class Context(dict):
         single YAML document with a single object whose top-level keys will be exported as
         variables.
         """
+        from .input import parse
         for variables in variable_sources:
             if isinstance(variables, Mapping):
                 self.update(variables)

--- a/emrichen/documents_list.py
+++ b/emrichen/documents_list.py
@@ -1,10 +1,13 @@
+from typing import Any, List
+
+
 class DocumentsList(list):
     pass
     # A marker for the YAML serializer to flatten this list into
     # documents at the top level.
 
 
-def flatten_documents_lists(input_list):
+def flatten_documents_lists(input_list: List[Any]) -> List[Any]:
     output_list = []
     for item in input_list:
         if isinstance(item, DocumentsList):

--- a/emrichen/input/__init__.py
+++ b/emrichen/input/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, TextIO, Union
+from typing import TextIO, Union
 
 from .json import load_json
 from .yaml import load_yaml
@@ -9,7 +9,7 @@ PARSERS = {
 }
 
 
-def parse(data: Union[TextIO, str], format: str) -> Any:
+def parse(data: Union[TextIO, str], format: str):
     if format in PARSERS:
         return PARSERS[format](data)
     else:

--- a/emrichen/input/__init__.py
+++ b/emrichen/input/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any, TextIO, Union
+
 from .json import load_json
 from .yaml import load_yaml
 
@@ -7,7 +9,7 @@ PARSERS = {
 }
 
 
-def parse(data, format):
+def parse(data: Union[TextIO, str], format: str) -> Any:
     if format in PARSERS:
         return PARSERS[format](data)
     else:

--- a/emrichen/input/json.py
+++ b/emrichen/input/json.py
@@ -16,7 +16,7 @@ def _hydrate_json_object(pairs: Any) -> Any:
                 try:
                     return make_compose(names=key, value=data)
                 except NoSuchTag as nst:
-                    raise NameError("in compose tag %s: can't find tag %s" % (key, nst.args[0])) from nst
+                    raise NameError("in compose tag {}: can't find tag {}".format(key, nst.args[0])) from nst
             if key not in tag_registry:
                 raise NoSuchTag(key)
             return tag_registry[key](data)

--- a/emrichen/input/json.py
+++ b/emrichen/input/json.py
@@ -1,12 +1,13 @@
 import json
 from collections import OrderedDict
+from typing import Any, List, TextIO, Union
 
 from ..exceptions import NoSuchTag
 from ..tags.base import tag_registry
 from .utils import make_compose
 
 
-def _hydrate_json_object(pairs):
+def _hydrate_json_object(pairs: Any) -> Any:
     if len(pairs) == 1:
         key, data = pairs[0]
         if key.startswith('!'):
@@ -22,11 +23,11 @@ def _hydrate_json_object(pairs):
     return OrderedDict(pairs)
 
 
-def json_load_or_loads(str_or_stream, **kwargs):
+def json_load_or_loads(str_or_stream: Union[TextIO, str], **kwargs) -> Any:
     if hasattr(str_or_stream, 'read'):
         str_or_stream = str_or_stream.read()
     return json.loads(str_or_stream, **kwargs)
 
 
-def load_json(data):
+def load_json(data: Union[TextIO, str]) -> List[Any]:
     return [json_load_or_loads(data, object_pairs_hook=_hydrate_json_object)]

--- a/emrichen/input/json.py
+++ b/emrichen/input/json.py
@@ -1,13 +1,13 @@
 import json
 from collections import OrderedDict
-from typing import Any, List, TextIO, Union
+from typing import List, TextIO, Union, Any
 
 from ..exceptions import NoSuchTag
-from ..tags.base import tag_registry
+from ..tags.base import tag_registry, BaseTag
 from .utils import make_compose
 
 
-def _hydrate_json_object(pairs: Any) -> Any:
+def _hydrate_json_object(pairs) -> Union[BaseTag, OrderedDict]:
     if len(pairs) == 1:
         key, data = pairs[0]
         if key.startswith('!'):
@@ -23,7 +23,7 @@ def _hydrate_json_object(pairs: Any) -> Any:
     return OrderedDict(pairs)
 
 
-def json_load_or_loads(str_or_stream: Union[TextIO, str], **kwargs) -> Any:
+def json_load_or_loads(str_or_stream: Union[TextIO, str], **kwargs):
     if hasattr(str_or_stream, 'read'):
         str_or_stream = str_or_stream.read()
     return json.loads(str_or_stream, **kwargs)

--- a/emrichen/input/utils.py
+++ b/emrichen/input/utils.py
@@ -1,8 +1,13 @@
+from typing import TYPE_CHECKING, Union
+
 from ..exceptions import NoSuchTag
 from ..tags.base import tag_registry
 
+if TYPE_CHECKING:
+    from ..tags.compose import Compose
 
-def make_compose(names, value):
+
+def make_compose(names: str, value: Union[str, dict]) -> 'Compose':
     if isinstance(names, str):
         names = [name.strip() for name in names.split(',')]
     for name in names:

--- a/emrichen/input/yaml.py
+++ b/emrichen/input/yaml.py
@@ -33,7 +33,7 @@ def construct_tagged_object(loader: yaml.Loader, node: yaml.Node) -> BaseTag:
             name = nst.args[0]
             raise ConstructorError(
                 None, None,
-                "in compose tag %s: can't find tag %s" % (node.tag, name),
+                "in compose tag {}: can't find tag {}".format(node.tag, name),
                 node.start_mark,
             ) from nst
     raise ConstructorError(
@@ -45,7 +45,7 @@ def construct_tagged_object(loader: yaml.Loader, node: yaml.Node) -> BaseTag:
 
 class RichLoader(yaml.SafeLoader):
     def __init__(self, stream) -> None:
-        super(RichLoader, self).__init__(stream)
+        super().__init__(stream)
         self.add_tag_constructors()
 
     def add_tag_constructors(self) -> None:

--- a/emrichen/input/yaml.py
+++ b/emrichen/input/yaml.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, TextIO, Union
+from typing import TextIO, Union
 
 import yaml
 from yaml.constructor import ConstructorError
@@ -9,7 +9,7 @@ from ..tags.base import BaseTag, tag_registry
 from .utils import make_compose
 
 
-def construct_tagless_yaml(loader: yaml.Loader, node: yaml.Node) -> Any:
+def construct_tagless_yaml(loader: yaml.Loader, node: yaml.Node):
     # From yaml.constructor.BaseConstructor#construct_object
     if isinstance(node, yaml.ScalarNode):
         constructor = loader.construct_scalar
@@ -59,5 +59,5 @@ class RichLoader(yaml.SafeLoader):
         return OrderedDict(loader.construct_pairs(node))
 
 
-def load_yaml(data: Union[TextIO, str]) -> Any:
+def load_yaml(data: Union[TextIO, str]):
     return list(yaml.load_all(data, Loader=RichLoader))

--- a/emrichen/output.py
+++ b/emrichen/output.py
@@ -1,13 +1,14 @@
 import json
 from pprint import pformat
+from typing import Any
 
 import pyaml
 import yaml
 
-from emrichen.documents_list import flatten_documents_lists
+from .documents_list import flatten_documents_lists
 
 
-def render_json(data):
+def render_json(data: Any) -> str:
     if not isinstance(data, list) or len(data) != 1:
         raise TypeError(
             "JSON output can only handle a single document. "
@@ -20,7 +21,7 @@ def render_json(data):
     return json.dumps(data[0], ensure_ascii=False, indent=2)
 
 
-def render_yaml(data):
+def render_yaml(data: Any) -> str:
     if isinstance(data, list):
         data = flatten_documents_lists(data)
     return yaml.dump_all(data,
@@ -37,7 +38,7 @@ RENDERERS = {
 }
 
 
-def render(data, format):
+def render(data, format: str) -> str:
     if format in RENDERERS:
         return RENDERERS[format](data)
     else:

--- a/emrichen/output.py
+++ b/emrichen/output.py
@@ -1,6 +1,5 @@
 import json
 from pprint import pformat
-from typing import Any
 
 import pyaml
 import yaml
@@ -8,7 +7,7 @@ import yaml
 from .documents_list import flatten_documents_lists
 
 
-def render_json(data: Any) -> str:
+def render_json(data) -> str:
     if not isinstance(data, list) or len(data) != 1:
         raise TypeError(
             "JSON output can only handle a single document. "
@@ -21,7 +20,7 @@ def render_json(data: Any) -> str:
     return json.dumps(data[0], ensure_ascii=False, indent=2)
 
 
-def render_yaml(data: Any) -> str:
+def render_yaml(data) -> str:
     if isinstance(data, list):
         data = flatten_documents_lists(data)
     return yaml.dump_all(data,

--- a/emrichen/tags/base.py
+++ b/emrichen/tags/base.py
@@ -4,7 +4,7 @@ tag_registry = {}
 
 
 class BaseMeta(type):
-    def __new__(meta: Type['BaseMeta'], name: str, bases: Any, class_dict: Dict[str, Any]) -> Any:
+    def __new__(meta: Type['BaseMeta'], name: str, bases, class_dict: Dict[str, Any]):
         cls = type.__new__(meta, name, bases, class_dict)
         if name[0] != '_' and name != 'BaseTag':
             tag_registry[name] = cls
@@ -15,7 +15,7 @@ class BaseTag(metaclass=BaseMeta):
     __slots__ = ['data']
     value_types = (str,)
 
-    def __init__(self, data: Any) -> None:
+    def __init__(self, data) -> None:
         self.data = data
         if not isinstance(data, self.value_types):
             raise TypeError('{self}: data not of valid type (valid types are {self.value_types}'.format(self=self))

--- a/emrichen/tags/base.py
+++ b/emrichen/tags/base.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict, Type
+
 tag_registry = {}
 
 
 class BaseMeta(type):
-    def __new__(meta, name, bases, class_dict):
+    def __new__(meta: Type['BaseMeta'], name: str, bases: Any, class_dict: Dict[str, Any]) -> Any:
         cls = type.__new__(meta, name, bases, class_dict)
         if name[0] != '_' and name != 'BaseTag':
             tag_registry[name] = cls
@@ -13,12 +15,12 @@ class BaseTag(metaclass=BaseMeta):
     __slots__ = ['data']
     value_types = (str,)
 
-    def __init__(self, data):
+    def __init__(self, data: Any) -> None:
         self.data = data
         if not isinstance(data, self.value_types):
             raise TypeError('{self}: data not of valid type (valid types are {self.value_types}'.format(self=self))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '{classname}.{data}'.format(
             classname=self.__class__.__name__,
             data=repr(self.data),

--- a/emrichen/tags/base64.py
+++ b/emrichen/tags/base64.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
 
+from ..context import Context
 from .base import BaseTag
 
 
@@ -11,7 +12,7 @@ class Base64(BaseTag):
     """
     value_types = (object,)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> str:
         data = context.enrich(self.data)
 
         if not isinstance(data, bytes):

--- a/emrichen/tags/compose.py
+++ b/emrichen/tags/compose.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from ..context import Context
 from .base import BaseTag, tag_registry
 
@@ -18,7 +16,7 @@ class Compose(BaseTag):
     '''
     value_types = (dict,)
 
-    def enrich(self, context: Context) -> Any:
+    def enrich(self, context: Context):
         value = self.data.get('value')
         for tag_name in reversed(self.data['tags']):
             tag_class = tag_registry[tag_name]

--- a/emrichen/tags/compose.py
+++ b/emrichen/tags/compose.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+from ..context import Context
 from .base import BaseTag, tag_registry
 
 
@@ -15,7 +18,7 @@ class Compose(BaseTag):
     '''
     value_types = (dict,)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         value = self.data.get('value')
         for tag_name in reversed(self.data['tags']):
             tag_class = tag_registry[tag_name]

--- a/emrichen/tags/concat.py
+++ b/emrichen/tags/concat.py
@@ -1,3 +1,4 @@
+from ..context import Context
 from .base import BaseTag
 
 
@@ -9,7 +10,7 @@ class Concat(BaseTag):
     """
     value_types = (list, BaseTag)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> list:
         result = []
         for iterable in context.enrich(self.data):
             result.extend(iterable)

--- a/emrichen/tags/debug.py
+++ b/emrichen/tags/debug.py
@@ -1,5 +1,7 @@
 import sys
+from typing import Any
 
+from ..context import Context
 from .base import BaseTag
 
 
@@ -14,7 +16,7 @@ class Debug(BaseTag):
 
     value_types = (object,)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         value = context.enrich(self.data)
         sys.stderr.write(str(value) + '\n')
         return value

--- a/emrichen/tags/defaults.py
+++ b/emrichen/tags/defaults.py
@@ -1,3 +1,4 @@
+from ..context import Context
 from .base import BaseTag
 
 
@@ -16,5 +17,5 @@ class Defaults(BaseTag):
     """
     value_types = (dict,)
 
-    def enrich(self, context):
+    def enrich(self, context: Context):
         raise ValueError('Defaults tag is unsupported anywhere else than document root.')

--- a/emrichen/tags/exists.py
+++ b/emrichen/tags/exists.py
@@ -1,3 +1,4 @@
+from ..context import Context
 from .base import BaseTag
 from .lookup import find_jsonpath_in_context
 
@@ -8,6 +9,6 @@ class Exists(BaseTag):
     example: "`!Exists foo`"
     description: Returns `true` if the JSONPath expression returns one or more matches, `false` otherwise.
     """
-    def enrich(self, context):
+    def enrich(self, context: Context) -> bool:
         matches = find_jsonpath_in_context(self.data, context)
         return bool(matches)

--- a/emrichen/tags/filter.py
+++ b/emrichen/tags/filter.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from typing import Any
 
 from ..context import Context
 from ..void import Void
@@ -16,7 +15,7 @@ class Filter(BaseTag):
     """
     value_types = (dict,)
 
-    def enrich(self, context: Context) -> Any:
+    def enrich(self, context: Context):
 
         as_ = str(self.data.get('as', 'item'))
         index_as = str(self.data.get('index_as') or '')

--- a/emrichen/tags/filter.py
+++ b/emrichen/tags/filter.py
@@ -1,8 +1,11 @@
 from collections import OrderedDict
+from typing import Any
 
+from ..context import Context
+from ..void import Void
 from .base import BaseTag
 from .loop import get_iterable
-from ..void import Void
+from .var import Var
 
 
 class Filter(BaseTag):
@@ -13,9 +16,7 @@ class Filter(BaseTag):
     """
     value_types = (dict,)
 
-    def enrich(self, context):
-        from ..context import Context
-        from .var import Var
+    def enrich(self, context: Context) -> Any:
 
         as_ = str(self.data.get('as', 'item'))
         index_as = str(self.data.get('index_as') or '')

--- a/emrichen/tags/format.py
+++ b/emrichen/tags/format.py
@@ -1,5 +1,6 @@
 import string
 
+from ..context import Context
 from .base import BaseTag
 from .lookup import find_jsonpath_in_context
 
@@ -35,5 +36,5 @@ class Format(BaseTag):
         JSONPath supported in variable lookup (eg. `{people[0].first_name}` will do the right thing).
         **NOTE:** When the format string starts with `{`, you need to quote it in order to avoid being interpreted as a YAML object.
     """
-    def enrich(self, context):
+    def enrich(self, context: Context) -> str:
         return JSONPathFormatter(tag=self, context=context).format(self.data)

--- a/emrichen/tags/hash.py
+++ b/emrichen/tags/hash.py
@@ -1,5 +1,6 @@
 import hashlib
 
+from ..context import Context
 from .base import BaseTag
 
 
@@ -11,7 +12,7 @@ class _BaseHash(BaseTag):
     """
     hasher = None
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> str:
         data = self.data
         if not isinstance(data, bytes):
             if not isinstance(data, str):

--- a/emrichen/tags/if_.py
+++ b/emrichen/tags/if_.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from ..context import Context
 from ..void import Void
 from .base import BaseTag
@@ -13,7 +11,7 @@ class If(BaseTag):
     """
     value_types = (dict,)
 
-    def enrich(self, context: Context) -> Any:
+    def enrich(self, context: Context):
         if 'test' not in self.data:
             raise ValueError('{self}: missing test'.format(self=self))
 

--- a/emrichen/tags/if_.py
+++ b/emrichen/tags/if_.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+from ..context import Context
 from ..void import Void
 from .base import BaseTag
 
@@ -10,7 +13,7 @@ class If(BaseTag):
     """
     value_types = (dict,)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         if 'test' not in self.data:
             raise ValueError('{self}: missing test'.format(self=self))
 

--- a/emrichen/tags/include.py
+++ b/emrichen/tags/include.py
@@ -1,12 +1,15 @@
 import base64
 import os
+from typing import Any, TextIO
 
-from .base import BaseTag
+from ..context import Context
+from ..template import Template
 from ..void import Void
+from .base import BaseTag
 
 
 class _BaseInclude(BaseTag):
-    def _open_file(self, context, mode='r'):
+    def _open_file(self, context: Context, mode: str = 'r') -> TextIO:
         include_path = os.path.join(
             os.path.dirname(context['__file__']), self.data)
 
@@ -20,13 +23,13 @@ class Include(_BaseInclude):
     description: Renders the requested template at this location. Both absolute and relative paths work.
     """
 
-    def get_template(self, context):
+    def get_template(self, context: Context) -> Template:
         from ..template import Template
 
         with self._open_file(context) as include_file:
             return Template.parse(include_file)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         template = self.get_template(context)
         enriched = template.enrich(context)
 
@@ -45,11 +48,11 @@ class IncludeText(_BaseInclude):
     description: Loads the given UTF-8 text file and returns the contents as a string.
     """
 
-    def get_data(self, context) -> bytes:
+    def get_data(self, context: Context) -> bytes:
         with self._open_file(context, 'rb') as include_file:
             return include_file.read()
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> str:
         return self.get_data(context).decode('UTF-8')
 
 
@@ -60,7 +63,7 @@ class IncludeBase64(IncludeText):
     description: Loads the given binary file and returns the contents encoded as Base64.
     """
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> str:
         data = super().get_data(context)
         return base64.b64encode(data).decode('UTF-8')
 
@@ -72,5 +75,5 @@ class IncludeBinary(IncludeText):
     description: Loads the given binary file and returns the contents as bytes.  This is practically only useful for hashing.
     """
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> bytes:
         return super().get_data(context)

--- a/emrichen/tags/include.py
+++ b/emrichen/tags/include.py
@@ -1,6 +1,6 @@
 import base64
 import os
-from typing import Any, TextIO
+from typing import TextIO
 
 from ..context import Context
 from ..template import Template
@@ -29,7 +29,7 @@ class Include(_BaseInclude):
         with self._open_file(context) as include_file:
             return Template.parse(include_file)
 
-    def enrich(self, context: Context) -> Any:
+    def enrich(self, context: Context):
         template = self.get_template(context)
         enriched = template.enrich(context)
 

--- a/emrichen/tags/index.py
+++ b/emrichen/tags/index.py
@@ -15,7 +15,7 @@ class _BaseIndex(Loop):
             as_ = data.get('as', 'item')
             data = dict(data, template=Var(as_))
 
-        super(_BaseIndex, self).__init__(data)
+        super().__init__(data)
 
 
 class Index(_BaseIndex):
@@ -34,7 +34,7 @@ class Index(_BaseIndex):
             as_ = data.get('as', 'item')
             data = dict(data, template=Var(as_))
 
-        super(Index, self).__init__(data)
+        super().__init__(data)
 
     def process_item(self, context: Context, output: dict, value, result) -> None:
 

--- a/emrichen/tags/index.py
+++ b/emrichen/tags/index.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from sys import stderr
 
+from ..context import Context
 from .loop import Loop
 from .var import Var
 
@@ -9,7 +10,7 @@ class _BaseIndex(Loop):
     value_types = (dict,)
     output_factory = OrderedDict
 
-    def __init__(self, data):
+    def __init__(self, data: dict) -> None:
         if 'template' not in data:
             as_ = data.get('as', 'item')
             data = dict(data, template=Var(as_))
@@ -28,15 +29,14 @@ class Index(_BaseIndex):
     example: TBD
     description: Makes a dict out of a list. Keys are determined by `by`.
     """
-    def __init__(self, data):
+    def __init__(self, data: dict) -> None:
         if 'template' not in data:
             as_ = data.get('as', 'item')
             data = dict(data, template=Var(as_))
 
         super(Index, self).__init__(data)
 
-    def process_item(self, context, output, value, result):
-        from ..context import Context
+    def process_item(self, context: Context, output: dict, value, result) -> None:
 
         by = self.data['by']
         result_as = self.data.get('result_as')
@@ -69,8 +69,7 @@ class Group(_BaseIndex):
     example: TBD
     description: Makes a dict out of a list. Keys are determined by `by`. Items with the same key are grouped in a list.
     """
-    def process_item(self, context, output, value, result):
-        from ..context import Context
+    def process_item(self, context: Context, output: dict, value, result) -> None:
 
         by = self.data['by']
         result_as = self.data.get('result_as')

--- a/emrichen/tags/join.py
+++ b/emrichen/tags/join.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 
+from ..context import Context
 from .base import BaseTag
 
 
@@ -18,7 +19,7 @@ class Join(BaseTag):
 
     value_types = (dict, list, BaseTag)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> str:
         if isinstance(self.data, Mapping):
             separator = context.enrich(self.data.get('separator', ' '))
             items = context.enrich(self.data['items'])

--- a/emrichen/tags/lookup.py
+++ b/emrichen/tags/lookup.py
@@ -1,14 +1,18 @@
-from .base import BaseTag
 from functools import lru_cache
+from typing import Any, List
+
 import jsonpath_rw
+
+from ..context import Context
+from .base import BaseTag
 
 
 @lru_cache()
-def parse_jsonpath(expr):
+def parse_jsonpath(expr: str) -> Any:
     return jsonpath_rw.parse(expr)
 
 
-def find_jsonpath_in_context(jsonpath_str, context):
+def find_jsonpath_in_context(jsonpath_str: str, context: Context) -> List[jsonpath_rw.DatumInContext]:
     return parse_jsonpath(jsonpath_str).find(context)
 
 
@@ -18,7 +22,7 @@ class Lookup(BaseTag):
     example: "`!Lookup people[0].first_name`"
     description: Performs a JSONPath lookup returning the first match. If there is no match, an error is raised.
     """
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         matches = find_jsonpath_in_context(self.data, context)
         if not matches:
             raise KeyError('{self}: no matches for {self.data}'.format(self=self))
@@ -31,5 +35,5 @@ class LookupAll(BaseTag):
     example: "`!LookupAll people[*].first_name`"
     description: Performs a JSONPath lookup returning all matches as a list. If no matches are found, the empty list `[]` is returned.
     """
-    def enrich(self, context):
+    def enrich(self, context: Context) -> List[Any]:
         return [context.enrich(m.value) for m in find_jsonpath_in_context(self.data, context)]

--- a/emrichen/tags/lookup.py
+++ b/emrichen/tags/lookup.py
@@ -8,7 +8,7 @@ from .base import BaseTag
 
 
 @lru_cache()
-def parse_jsonpath(expr: str) -> Any:
+def parse_jsonpath(expr: str):
     return jsonpath_rw.parse(expr)
 
 
@@ -22,7 +22,7 @@ class Lookup(BaseTag):
     example: "`!Lookup people[0].first_name`"
     description: Performs a JSONPath lookup returning the first match. If there is no match, an error is raised.
     """
-    def enrich(self, context: Context) -> Any:
+    def enrich(self, context: Context):
         matches = find_jsonpath_in_context(self.data, context)
         if not matches:
             raise KeyError('{self}: no matches for {self.data}'.format(self=self))

--- a/emrichen/tags/loop.py
+++ b/emrichen/tags/loop.py
@@ -6,7 +6,7 @@ from ..documents_list import DocumentsList
 from .base import BaseTag
 
 
-def get_iterable(tag: BaseTag, over: Any, context: Context, index_start: Optional[int] = None) -> Iterable[Any]:
+def get_iterable(tag: BaseTag, over, context: Context, index_start: Optional[int] = None) -> Iterable[Any]:
     if isinstance(over, str) and over in context:
         # This does mean you can't explicitly iterate over strings that are keys
         # in the context, but if you really do need to do that, you may need to
@@ -52,7 +52,7 @@ class Loop(BaseTag):
     value_types = (dict,)
     output_factory = list
 
-    def enrich(self, context: Context) -> Any:
+    def enrich(self, context: Context):
         from ..context import Context
 
         as_ = str(self.data.get('as', 'item'))
@@ -92,7 +92,7 @@ class Loop(BaseTag):
     def get_iterable(self, context: Context, index_start: Optional[int]) -> Tuple[enumerate, bool]:
         return get_iterable(self, self.data.get('over'), context, index_start)
 
-    def process_item(self, context: Context, output: Any, value: Any, result: Any) -> None:
+    def process_item(self, context: Context, output, value, result) -> None:
         '''
         Used by Loop subclasses to do things every iteration.
         '''

--- a/emrichen/tags/loop.py
+++ b/emrichen/tags/loop.py
@@ -1,10 +1,12 @@
 from collections.abc import Mapping, Sequence
+from typing import Any, Iterable, Optional, Tuple
 
+from ..context import Context
 from ..documents_list import DocumentsList
 from .base import BaseTag
 
 
-def get_iterable(tag, over, context, index_start=None):
+def get_iterable(tag: BaseTag, over: Any, context: Context, index_start: Optional[int] = None) -> Iterable[Any]:
     if isinstance(over, str) and over in context:
         # This does mean you can't explicitly iterate over strings that are keys
         # in the context, but if you really do need to do that, you may need to
@@ -50,7 +52,7 @@ class Loop(BaseTag):
     value_types = (dict,)
     output_factory = list
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         from ..context import Context
 
         as_ = str(self.data.get('as', 'item'))
@@ -87,10 +89,10 @@ class Loop(BaseTag):
             self.process_item(subcontext, output, value, result)
         return output
 
-    def get_iterable(self, context, index_start):
+    def get_iterable(self, context: Context, index_start: Optional[int]) -> Tuple[enumerate, bool]:
         return get_iterable(self, self.data.get('over'), context, index_start)
 
-    def process_item(self, context, output, value, result):
+    def process_item(self, context: Context, output: Any, value: Any, result: Any) -> None:
         '''
         Used by Loop subclasses to do things every iteration.
         '''

--- a/emrichen/tags/merge.py
+++ b/emrichen/tags/merge.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from ..context import Context
 from .base import BaseTag
 
 
@@ -11,7 +12,7 @@ class Merge(BaseTag):
     """
     value_types = (list, BaseTag)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> OrderedDict:
         result = OrderedDict()
         for iterable in context.enrich(self.data):
             result.update(iterable)

--- a/emrichen/tags/not_.py
+++ b/emrichen/tags/not_.py
@@ -1,3 +1,4 @@
+from ..context import Context
 from .base import BaseTag
 
 
@@ -9,5 +10,5 @@ class Not(BaseTag):
     """
     value_types = (object,)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> bool:
         return not context.enrich(self.data)

--- a/emrichen/tags/op.py
+++ b/emrichen/tags/op.py
@@ -1,7 +1,8 @@
 import operator
+from typing import Any
 
+from ..context import Context
 from .base import BaseTag
-
 
 operator_list = [
     (('=', '==', '===', 'eq'), operator.eq),
@@ -32,7 +33,7 @@ class Op(BaseTag):
     description: Performs binary operators. Especially useful with `!If` to implement greater-than etc.
     """
     value_types = (dict, list)
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         if isinstance(self.data, dict):
             a = context.enrich(self.data['a'])
             op_name = context.enrich(self.data['op'])

--- a/emrichen/tags/op.py
+++ b/emrichen/tags/op.py
@@ -1,5 +1,4 @@
 import operator
-from typing import Any
 
 from ..context import Context
 from .base import BaseTag
@@ -33,7 +32,8 @@ class Op(BaseTag):
     description: Performs binary operators. Especially useful with `!If` to implement greater-than etc.
     """
     value_types = (dict, list)
-    def enrich(self, context: Context) -> Any:
+
+    def enrich(self, context: Context):
         if isinstance(self.data, dict):
             a = context.enrich(self.data['a'])
             op_name = context.enrich(self.data['op'])

--- a/emrichen/tags/typeop.py
+++ b/emrichen/tags/typeop.py
@@ -1,5 +1,5 @@
 from numbers import Number
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from ..context import Context
 from ..void import Void, VoidType
@@ -18,7 +18,7 @@ class _BaseIsType(BaseTag):
     def enrich(self, context: Context) -> bool:
         return self.check(context.enrich(self.data))
 
-    def check(self, value: Any) -> bool:
+    def check(self, value) -> bool:
         return isinstance(value, self.requisite_type)
 
 

--- a/emrichen/tags/typeop.py
+++ b/emrichen/tags/typeop.py
@@ -1,6 +1,8 @@
 from numbers import Number
+from typing import Any, Optional, Union
 
-from emrichen.void import Void
+from ..context import Context
+from ..void import Void, VoidType
 from .base import BaseTag
 
 
@@ -13,10 +15,10 @@ class _BaseIsType(BaseTag):
     requisite_type = None
     value_types = (object,)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> bool:
         return self.check(context.enrich(self.data))
 
-    def check(self, value):
+    def check(self, value: Any) -> bool:
         return isinstance(value, self.requisite_type)
 
 
@@ -34,7 +36,7 @@ class IsInteger(_BaseIsType):
     __doc__ = _BaseIsType.__doc__
     requisite_type = int
 
-    def check(self, value):
+    def check(self, value: Union[int, float, bool]) -> bool:
         # Special case: True and False are integers as far as
         # Python is concerned.
         if value is True or value is False:
@@ -64,5 +66,5 @@ class IsNone(_BaseIsType):
     description: Returns True if the value enriched is None (null) or Void, False otherwise.
     """
 
-    def check(self, value):
+    def check(self, value: Optional[Union[VoidType, str]]) -> bool:
         return (value is None or value is Void)

--- a/emrichen/tags/urlencode.py
+++ b/emrichen/tags/urlencode.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
-from urllib.parse import quote_plus, urlparse, urlunparse, parse_qsl, urlencode
+from urllib.parse import parse_qsl, quote_plus, urlencode, urlparse, urlunparse
 
+from ..context import Context
 from .base import BaseTag
 
 
@@ -45,7 +46,7 @@ class URLEncode(BaseTag):
 
     value_types = (dict, str, BaseTag)
 
-    def enrich(self, context):
+    def enrich(self, context: Context) -> str:
         if isinstance(self.data, Mapping):
             url = context.enrich(self.data.get('url'))
             query = context.enrich(self.data.get('query'))

--- a/emrichen/tags/var.py
+++ b/emrichen/tags/var.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from ..context import Context
 from .base import BaseTag
 
@@ -10,5 +8,5 @@ class Var(BaseTag):
     example: "`!Var image_name`"
     description: Replaced with the value of the variable.
     """
-    def enrich(self, context: Context) -> Any:
+    def enrich(self, context: Context):
         return context.enrich(context[self.data])

--- a/emrichen/tags/var.py
+++ b/emrichen/tags/var.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+from ..context import Context
 from .base import BaseTag
 
 
@@ -7,5 +10,5 @@ class Var(BaseTag):
     example: "`!Var image_name`"
     description: Replaced with the value of the variable.
     """
-    def enrich(self, context):
+    def enrich(self, context: Context) -> Any:
         return context.enrich(context[self.data])

--- a/emrichen/tags/void.py
+++ b/emrichen/tags/void.py
@@ -1,4 +1,6 @@
+from ..context import Context
 from ..void import Void as VoidObj
+from ..void import VoidType
 from .base import BaseTag
 
 
@@ -9,5 +11,6 @@ class Void(BaseTag):
     description: The dict key, list item or YAML document that resolves to `!Void` is removed from the output.
     """
     value_types = (object,)
-    def enrich(self, context):
+
+    def enrich(self, context: Context) -> VoidType:
         return VoidObj

--- a/emrichen/tags/with_.py
+++ b/emrichen/tags/with_.py
@@ -1,3 +1,4 @@
+from ..context import Context
 from .base import BaseTag
 
 
@@ -11,9 +12,7 @@ class With(BaseTag):
     """
     value_types = (dict,)
 
-    def enrich(self, context):
-        from ..context import Context
-
+    def enrich(self, context: Context) -> int:
         vars_ = self.data['vars']
         template = self.data['template']
 

--- a/emrichen/template.py
+++ b/emrichen/template.py
@@ -15,7 +15,7 @@ def determine_format(filename: Optional[str], choices: Dict[str, Callable], defa
 
 
 class Template:
-    def __init__(self, template: Any, filename: Optional[str]=None) -> None:
+    def __init__(self, template, filename: Optional[str]=None) -> None:
         if not isinstance(template, list):
             raise TypeError(
                 '`template` must be a list of objects; {template} is not. Are you maybe looking for Template.parse()?'.format(
@@ -26,7 +26,7 @@ class Template:
         self.template, self.defaults = extract_defaults(template, filename)
         self.filename = filename
 
-    def enrich(self, context: Union[dict, Context]) -> Any:
+    def enrich(self, context: Union[dict, Context]):
         context = Context(self.defaults, context, __file__=self.filename)
         return context.enrich(self.template)
 
@@ -46,7 +46,7 @@ class Template:
         return cls(template=parse(data, format=format), filename=filename)
 
 
-def extract_defaults(template: Any, filename: Optional[str]) -> Tuple[list, dict]:
+def extract_defaults(template, filename: Optional[str]) -> Tuple[list, dict]:
     from .tags import Defaults, Include
     defaults = {}
 

--- a/emrichen/template.py
+++ b/emrichen/template.py
@@ -14,7 +14,7 @@ def determine_format(filename: Optional[str], choices: Dict[str, Callable], defa
     return default
 
 
-class Template(object):
+class Template:
     def __init__(self, template: Any, filename: Optional[str]=None) -> None:
         if not isinstance(template, list):
             raise TypeError(


### PR DESCRIPTION
Initial type annotations were added with [MonkeyType](https://github.com/instagram/monkeytype) (`monkeytype run -m pytest -ra` & `for module in (monkeytype list-modules | grep -v tests); monkeytype apply --sample-count $module; end`), then cleaned up by hand to avoid some `Union[...]` monstrosities.

Some imports, mainly in `context.py`, had to be moved into function-locals to avoid circular imports.

In addition, `pyupgrade` was run to replace some old-school percent formatting with `.format()`.