### PR TITLE
WIP: partial fix for #15 (NOTE: needs further testing and emrobustening)

### DIFF
--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -68,7 +68,6 @@ def test_lookup_no_match():
     assert 'no matches for' in str(ei.value)
 
 
-@pytest.mark.xfail
 def test_late_enrich():
     template = Template.parse('''
 !Defaults

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -97,3 +97,17 @@ should_contain_5: !Loop
   template: !Var item
 ''')
     assert template.enrich({}) == [{'should_contain_5': [5]}]
+
+
+@pytest.mark.xfail
+def test_recursive_data_structure():
+    template = Template.parse('''
+!Defaults
+x:
+    y: 5
+    x: !Var x
+---
+five: !Lookup x.y
+also_five: !Lookup x.x.x.x.x.y
+''')
+    assert template.enrich({}) == [{'five': 5, 'also_five': 5}]


### PR DESCRIPTION
Added a proxy that enriches on the fly.

Fixes `tests/test_lookup.py:test_late_enrich` and `examples/peano.yml`, but I'm pretty sure it introduces bugs elsewhere.

Also this unwraps only one layer of laziness, perhaps it should be made recursive.