### PR TITLE
Move pyaml to an extra dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Python 3.5+ required. Python 2 is not and will not be supported.
 
     pip3 install emrichen
 
+To serialize YAML documents in a more human-readable way, the `pyaml` library is required. This can be installed separately,
+or via the `[pretty]` [extra](https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras), i.e.
+
+    pip3 install emrichen[pretty]
+
 ## Supported tags
 
 <!-- This table is updated by `update_readme.py`; please don't edit by hand. -->

--- a/emrichen/output.py
+++ b/emrichen/output.py
@@ -1,8 +1,12 @@
 import json
 from pprint import pformat
 
-import pyaml
 import yaml
+
+try:
+    import pyaml
+except ImportError:
+    pyaml = None
 
 from .documents_list import flatten_documents_lists
 
@@ -24,7 +28,7 @@ def render_yaml(data) -> str:
     if isinstance(data, list):
         data = flatten_documents_lists(data)
     return yaml.dump_all(data,
-        Dumper=pyaml.PrettyYAMLDumper,
+        Dumper=(pyaml.PrettyYAMLDumper if pyaml else yaml.Dumper),
         allow_unicode=True,
         default_flow_style=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
             'emrichen = emrichen.__main__:main',
         ]
     },
-    install_requires=["PyYAML", "pyaml", "jsonpath-rw~=1.4.0"],
-    extras_require={"dev": dev_requirements},
+    install_requires=["PyYAML", "jsonpath-rw~=1.4.0"],
+    extras_require={"dev": dev_requirements, "pretty": ["pyaml"]},
     tests_require=dev_requirements,
     setup_requires=["pytest-runner"],
 )


### PR DESCRIPTION
There's no real reason to always depend on `pyaml`; after all, one might expect the templates rendered by Emrichen to be consumed by machines.